### PR TITLE
Add bar repeat feature as a plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,49 +89,31 @@ Some alternatives:
 
 ```vim
 " one char wide solid vertical bar
-let g:line_no_indicator_chars = [
-  \  ' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'
-  \  ]
+let g:line_no_indicator_chars =
+  \ [' ', '▁', '▂', '▃', '▄', '▅', '▆', '▇', '█']
 
 " two char wide fade-in blocks
-let g:line_no_indicator_chars = [
-  \ '  ', '░ ', '▒ ', '▓ ', '█ ', '█░', '█▒', '█▓', '██'
-  \ ]
+let g:line_no_indicator_chars =
+  \ ['  ', '░ ', '▒ ', '▓ ', '█ ', '█░', '█▒', '█▓', '██']
 
 " three char wide solid horizontal bar
-let g:line_no_indicator_chars = [
-  \ '   ', '▏  ', '▎  ', '▍  ', '▌  ',
-  \ '▋  ', '▊  ', '▉  ', '█  ', '█▏ ',
-  \ '█▎ ', '█▍ ', '█▌ ', '█▋ ', '█▊ ',
-  \ '█▉ ', '██ ', '██▏', '██▎', '██▍',
-  \ '██▌', '██▋', '██▊', '██▉', '███'
+let g:line_no_indicator_chars =
+  \ [ '   ', '▏  ', '▎  ', '▍  ', '▌  '
+  \ , '▋  ', '▊  ', '▉  ', '█  ', '█▏ '
+  \ , '█▎ ', '█▍ ', '█▌ ', '█▋ ', '█▊ '
+  \ , '█▉ ', '██ ', '██▏', '██▎', '██▍'
+  \ , '██▌', '██▋', '██▊', '██▉', '███'
   \ ]
 
-" takes char sequence list and a number of how many times you want to repeat it
-fu! s:repeat_bar(bar_char_seq, repeat_n_times, ...)
-  let l:n = get(a:, 1, 0)
-  let l:single_len = len(a:bar_char_seq)
-  if l:n > l:single_len * a:repeat_n_times | retu [] | en
-  let l:x = ''
-  for l:i in range(a:repeat_n_times, 1, -1)
-    let l:idx = max([0, (l:single_len * l:i) - l:n])
-    let l:idx = min([l:single_len - 1, l:idx])
-    let l:x .= a:bar_char_seq[l:idx]
-  endfo
-  retu add(s:repeat_bar(a:bar_char_seq, a:repeat_n_times, l:n + 1), l:x)
-endf
-
-" six char wide solid horizontal bar (from '      ' to '██████')
-" (replace 6 with 3 to get that three char wide bar shown above)
-let g:line_no_indicator_chars = s:repeat_bar(
-  \ [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉', '█'],
-  \ 6
-  \ )
+" the same three char wide solid horizontal bar as above
+let g:line_no_indicator_bar_repeats = 3
+let g:line_no_indicator_chars = [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉', '█']
 
 " from 9 spaces ('         ') to 9 dots ('.........')
-let g:line_no_indicator_chars = s:repeat_bar(['   ', '.  ', '.. ', '...'], 3)
-
+let g:line_no_indicator_bar_repeats = 3
+let g:line_no_indicator_chars = ['   ', '.  ', '.. ', '...']
 ```
+
 Note: The above chars might look a little janky in your browser, but probably
 render okay in your terminal.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,31 @@ let g:line_no_indicator_chars = [
   \ '█▉ ', '██ ', '██▏', '██▎', '██▍',
   \ '██▌', '██▋', '██▊', '██▉', '███'
   \ ]
- 
+
+" takes char sequence list and a number of how many times you want to repeat it
+fu! s:repeat_bar(bar_char_seq, repeat_n_times, ...)
+  let l:n = get(a:, 1, 0)
+  let l:single_len = len(a:bar_char_seq)
+  if l:n > l:single_len * a:repeat_n_times | retu [] | en
+  let l:x = ''
+  for l:i in range(a:repeat_n_times, 1, -1)
+    let l:idx = max([0, (l:single_len * l:i) - l:n])
+    let l:idx = min([l:single_len - 1, l:idx])
+    let l:x .= a:bar_char_seq[l:idx]
+  endfo
+  retu add(s:repeat_bar(a:bar_char_seq, a:repeat_n_times, l:n + 1), l:x)
+endf
+
+" six char wide solid horizontal bar (from '      ' to '██████')
+" (replace 6 with 3 to get that three char wide bar shown above)
+let g:line_no_indicator_chars = s:repeat_bar(
+  \ [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉', '█'],
+  \ 6
+  \ )
+
+" from 9 spaces ('         ') to 9 dots ('.........')
+let g:line_no_indicator_chars = s:repeat_bar(['   ', '.  ', '.. ', '...'], 3)
+
 ```
 Note: The above chars might look a little janky in your browser, but probably
 render okay in your terminal.

--- a/plugin/line-no-indicator.vim
+++ b/plugin/line-no-indicator.vim
@@ -30,12 +30,19 @@ function! LineNoIndicator() abort
   let l:result = ''
 
   for l:i in range(g:line_no_indicator_bar_repeats)
-    let l:line_no_fraction = floor(l:current_line) / floor(l:total_lines)
-    let l:line_no_fraction *= g:line_no_indicator_bar_repeats
-    let l:line_no_fraction -= l:i
-    let l:index = float2nr(l:line_no_fraction * l:single_len)
-    let l:index = min([l:single_len, max([0, l:index])])
-    let l:result .= g:line_no_indicator_chars[l:index]
+    let l:line_no_fraction =
+      \ ( floor(l:current_line)
+      \ / floor(l:total_lines)
+      \ * g:line_no_indicator_bar_repeats
+      \ ) - l:i
+
+    let l:index =
+      \ min([l:single_len,
+      \ max([0,
+      \ float2nr(l:line_no_fraction * l:single_len)
+      \ ])])
+
+    let l:result = l:result . g:line_no_indicator_chars[l:index]
   endfor
 
   return l:result

--- a/plugin/line-no-indicator.vim
+++ b/plugin/line-no-indicator.vim
@@ -18,19 +18,25 @@ if !exists('g:line_no_indicator_chars')
   end
 end
 
+if !exists('g:line_no_indicator_bar_repeats')
+  let g:line_no_indicator_bar_repeats = 1
+en
+
 function! LineNoIndicator() abort
   " Zero index line number so 1/3 = 0, 2/3 = 0.5, and 3/3 = 1
   let l:current_line = line('.') - 1
   let l:total_lines = line('$') - 1
+  let l:single_len = len(g:line_no_indicator_chars) - 1
+  let l:result = ''
 
-  if l:current_line == 0
-    let l:index = 0
-  elseif l:current_line == l:total_lines
-    let l:index = -1
-  else
+  for l:i in range(g:line_no_indicator_bar_repeats)
     let l:line_no_fraction = floor(l:current_line) / floor(l:total_lines)
-    let l:index = float2nr(l:line_no_fraction * len(g:line_no_indicator_chars))
-  endif
+    let l:line_no_fraction *= g:line_no_indicator_bar_repeats
+    let l:line_no_fraction -= l:i
+    let l:index = float2nr(l:line_no_fraction * l:single_len)
+    let l:index = min([l:single_len, max([0, l:index])])
+    let l:result .= g:line_no_indicator_chars[l:index]
+  endfor
 
-  return g:line_no_indicator_chars[l:index]
+  return l:result
 endfunction

--- a/plugin/line-no-indicator.vim
+++ b/plugin/line-no-indicator.vim
@@ -26,22 +26,51 @@ function! LineNoIndicator() abort
   " Zero index line number so 1/3 = 0, 2/3 = 0.5, and 3/3 = 1
   let l:current_line = line('.') - 1
   let l:total_lines = line('$') - 1
-  let l:single_len = len(g:line_no_indicator_chars) - 1
+
+  " Length of list of single cycle of a repeat
+  " minus one (4 for default g:line_no_indicator_chars).
+  " Count of steps of one full cycle of indicator from minimum to maximum value
+  " (but minus one because we're dealing with 0-index below).
+  let l:indicator_full_cycle_steps = len(g:line_no_indicator_chars) - 1
+
+  " Result Line No Indicator string accumulator
   let l:result = ''
 
+  " Iterating over repeats starting from 0 (zero)
   for l:i in range(g:line_no_indicator_bar_repeats)
+    " Coefficient (from 0 to 1) of current line position multiplied by count of
+    " repeats and shifted (minus) with current repeat index (starting from 0).
+    " So if g:line_no_indicator_bar_repeats is 3 the first value will be in
+    " between 0 and 3, second will be in between -1 and 2 and thrid -2 and 1.
+    " Value from 0 to 1 indicates coefficient of current repeat state, it it's
+    " bigger it means current state is maximum, if it's lower it means current
+    " state is minimum. Below we're limiting it to 0 and 1 boundaries.
     let l:line_no_fraction =
       \ ( floor(l:current_line)
       \ / floor(l:total_lines)
       \ * g:line_no_indicator_bar_repeats
       \ ) - l:i
 
+    " We're multiplying steps count of one repeat cycle (minus one) by
+    " l:line_no_fraction coefficient of current repeat state and fit it in
+    " boundaries.
+    " It's relative to current repeat.
+    " If it's lower than minimum it means all the next repeats have minimum
+    " value, if it's bigger it means all the previous repeats have maximum
+    " value.
+    " Getting absolute index of whole indicator (including repeats),
+    " when it's lower than current repeat we set it to 0 and when it's bigger
+    " than maximum of full cycle steps we set it to maximum value.
     let l:index =
-      \ min([l:single_len,
+      \ min([l:indicator_full_cycle_steps,
       \ max([0,
-      \ float2nr(l:line_no_fraction * l:single_len)
+      \ float2nr(l:line_no_fraction * l:indicator_full_cycle_steps)
       \ ])])
 
+    " Appending to accumulator another repeated (or only single one) indicator
+    " char (or 'chars' if you have multiple chars indicator in
+    " g:line_no_indicator_chars like ['   ', '.  ', '.. ', '...']) with properly
+    " calculated state of current repeat index.
     let l:result = l:result . g:line_no_indicator_chars[l:index]
   endfor
 


### PR DESCRIPTION
I just have written this for myself in order to be able to change wideness of the bar more easily, potentially dynamically, and decided to share this as a usage example.

My config of the bar: https://github.com/unclechu/neovimrc/blob/01bbed8d85c86a44140a44eca4baf508e4a5b0c5/plugins-configs.vim#L53-L74

_P.S. I found this plug-in repo from Mastering Vim Quickly e-mail newsletter._

**UPD:**

Added an option `g:line_no_indicator_bar_repeats` with a number of repeats.
Added usage examples to `README.md`.